### PR TITLE
Correct syntax for not availabel file in SWS modelling routine

### DIFF
--- a/03_modeling/SWS_modeling_calc_misfit.m
+++ b/03_modeling/SWS_modeling_calc_misfit.m
@@ -27,17 +27,17 @@ function modsall_sort = SWS_modeling_calc_misfit(modelsin, modrange_low, modrang
 %
 % 2) define input variables
 % 
-%    modelsin = 'sws_modout_domper8s.mat' % (be sure to have that file in the
+%    modelsin = 'sws_modout_domper8s.mat'; % (be sure to have that file in the
 %                                         % current directory!)
-%    modrange_low = 3
-%    modrange_upp = 90
-%    datasplit = 'splitresults_PERM_FIN_KEF.txt'
-%    datanull = 'splitresultsNULL_PERM_FIN_KEF.txt',
-%    datastack = 'KEF_stackresults.mat'
+%    modrange_low = 3;
+%    modrange_upp = 90;
+%    datasplit = 'splitresults_PERM_FIN_KEF.txt';
+%    datanull = 'splitresultsNULL_PERM_FIN_KEF.txt';
+%    datastack = 'KEF_stackresults.mat';
 %
 % 3) run misfit routine
 %    
-%    modsall_sort = SWS_modeling_calc_misfit(modelsin, modrange_low, modrange_upp, datasplit, datanull, datastack)
+%    modsall_sort = SWS_modeling_calc_misfit(modelsin, modrange_low, modrange_upp, datasplit, datanull, datastack);
 %
 % .........................................................................
 % .........................................................................

--- a/03_modeling/SWS_modeling_calc_misfit.m
+++ b/03_modeling/SWS_modeling_calc_misfit.m
@@ -17,7 +17,7 @@ function modsall_sort = SWS_modeling_calc_misfit(modelsin, modrange_low, modrang
 %
 % all data (datasplit, datanull, datastack) needs to be in standard SplitLab and/or
 % StackSplit output format! If one file is not available, set the
-% corresponding parameter to empty (e.g. datastack =[]).
+% corresponding parameter to empty (e.g. datastack="").
 %
 % .........................................................................
 % .........................................................................


### PR DESCRIPTION
This PR addresses an error in the INPUT section of the function `SWS_modeling_calc_misfit.m`.

Using `[]` to indicate a not available input file causes an MATLAB error, as the function `dir.m` expects an text scaler. Instead, the user has to pass `""` for a not available file.

**Error message**

```
Error using dir
Name must be a text scalar.

Error in SWS_modeling_calc_misfit (line 144)
dir_res_stack=dir(datastack);
```