### PR TITLE
Add missing `'markerFacecolor'` of nulls for the case `'none'` is used for `colmap`

### DIFF
--- a/01_stereoplots/SWS_Analysis_BASICS_stereoplot.m
+++ b/01_stereoplots/SWS_Analysis_BASICS_stereoplot.m
@@ -318,7 +318,7 @@ hold on
 % Nulls
 for KK=1:length(RES_nulls)
     if ~isempty(RES_nulls) && fast_col==0
-        plotm(90-inc_nulls(KK), bazi_nulls(KK) ,'o','color',nullcol, 'MarkerSize',marks,'linewidth',linewcirc);
+        plotm(90-inc_nulls(KK), bazi_nulls(KK) ,'o','color',nullcol, 'MarkerSize',marks,'linewidth',linewcirc,'markerFacecolor','w');
     elseif  ~isempty(RES_nulls) && fast_col==1
         cmap=usecmap;
         colormap(cmap);


### PR DESCRIPTION
In the function `01_stereoplots/SWS_Analysis_BASICS_stereoplot.m`  the fill color of the circles to represent the _nulls_ is missing for the case the argument `'none'` is used for `colmap`. This PR adds `'markerFacecolor','w'` to the code.

Figure based on available single-event analysis test data:
![SWS_stereo_markerFacecolor_nulls_cpt_none](https://user-images.githubusercontent.com/94163266/191093296-610fc7d9-bb4f-4c8c-aafe-956ca1daf2c5.png)
