### PR TITLE
Add missing test for STACK data for the case `'none'` is used for `colmap`

### DIFF
--- a/01_stereoplots/SWS_Analysis_BASICS_stereoplot.m
+++ b/01_stereoplots/SWS_Analysis_BASICS_stereoplot.m
@@ -491,7 +491,9 @@ colormap(usecmap);
 
 else
     set(hndl,'color',splitcol,'linewidth',2.5)
-    set(hndlstack,'color',stackcol,'linewidth',2.5)
+    if exist('RES_STACK','var') && plotmulti==1
+        set(hndlstack,'color',stackcol,'linewidth',2.5)
+    end
 end
 
 else


### PR DESCRIPTION
In the function `01_stereoplots/SWS_Analysis_BASICS_stereoplot.m` the if-lope to test for STACK data is missing for the case the argument `'none'` is used for `colmap`. This PR adds this if-lope.

---------------------
Error message (without the added if-lope):
```
Unrecognized function or variable 'hndlstack'.

Error in SWS_Analysis_BASICS_stereoplot (line 495)
        set(hndlstack,'color',stackcol,'linewidth',2.5)
```
 